### PR TITLE
fix aws method type in example

### DIFF
--- a/examples/tfvaultenv.config.hcl
+++ b/examples/tfvaultenv.config.hcl
@@ -15,7 +15,7 @@ ad "infoblox" {
 }
 
 aws "sts" {
-   method = "sts"
+   method = "assumed_role"
    role = "terraform"
    role_arn = "arn:aws:iam::0000000000:role/Terraform"
    ttl = 900


### PR DESCRIPTION
in v0.2.0 the AWS method was changed to align with the Vault secrets engine naming. 