### PR TITLE
Add new feature: expand_env_vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ kv_secret "infoblox" {
 - `attribute_map`: (Optional) Map of kv2 secret attribute names to provider values. Defaults to username and password
 - `target_provider`: (Required) Name of the Terraform provider to generate environment variables for
 - `extra_env_vars`: (Optional) Map of additional environment variables to set
+- `expand_env_vars`: (Optional) Perform shell expansion of variables in the string. This only applies to values in `extra_env_vars`
 
 #### Kv2 Secret (Generic)
 
@@ -171,7 +172,7 @@ kv_secret "generic" {
 - `attribute_map`: (Optional) Map of kv2 secret attribute names to environment vasriable keys. 
 - `target_provider`: (Required) generic
 - `extra_env_vars`: (Optional) Map of additional environment variables to set
-
+- `expand_env_vars`: (Optional) Perform shell expansion of variables in the string. This only applies to values in `extra_env_vars`
 ### Auth Methods
 
 By default `tfvaultenv` creates an implicit auth method that supports token based authentication in the form of VAULT_TOKEN, ~/.vault-token, and token helpers. Supported auth methods such as JWT (see below) can be used and can override token auth by configuring a priority of 1 or above. Auth methods can be conditionally activated using `when {}` blocks based on environment variables or other supported conditions. When multiple auth methods are defined you can specify priorities to ensure that the preferred fallback auth method is used.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,7 @@ func ProcessConfig(c *Config) error {
 				v.PasswordEnvVar: secret.CurrentPassword,
 			}
 
-			_, err = providers.SetGenericEnv(secretMap, v.ExtraEnvVars)
+			_, err = providers.SetGenericEnv(secretMap, v.ExtraEnvVars, v.ExpandEnv)
 			if err != nil {
 				return errors.Wrap(err, "failed to set generic environment variables")
 			}
@@ -220,7 +220,7 @@ func ProcessConfig(c *Config) error {
 				return errors.Wrap(err, "reading Vault kv2 secrets engine")
 			}
 
-			_, err = providers.SetGenericEnv(secretMap, v.ExtraEnvVars)
+			_, err = providers.SetGenericEnv(secretMap, v.ExtraEnvVars, v.ExpandEnv)
 			if err != nil {
 				return errors.Wrap(err, "failed to set generic environment variables")
 			}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -78,6 +78,7 @@ type Ad struct {
 	UsernameEnvVar string            `hcl:"username_env_var,optional"`
 	PasswordEnvVar string            `hcl:"password_env_var,optional"`
 	ExtraEnvVars   map[string]string `hcl:"extra_env_vars,optional"`
+	ExpandEnv      bool              `hcl:"expand_env_vars,optional"`
 }
 
 type KvSecret struct {
@@ -87,6 +88,7 @@ type KvSecret struct {
 	TargetProvider string            `hcl:"target_provider"`
 	AttributeMap   map[string]string `hcl:"attribute_map,optional"`
 	ExtraEnvVars   map[string]string `hcl:"extra_env_vars,optional"`
+	ExpandEnv      bool              `hcl:"expand_env_vars,optional"`
 }
 
 type When struct {

--- a/internal/providers/generic.go
+++ b/internal/providers/generic.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 )
 
-func SetGenericEnv(genericEnvVars map[string]string, extraEnvVars map[string]string) (string, error) {
+func SetGenericEnv(genericEnvVars map[string]string, extraEnvVars map[string]string, expandEnv bool) (string, error) {
 	for k, v := range genericEnvVars {
 		fmt.Printf("%s=%s\n", k, v)
 	}
 
 	for k, v := range extraEnvVars {
-		fmt.Printf("%s=%s\n", k, v)
+		s := fmt.Sprintf("%s=%s\n", k, v)
+		printEnv(s, expandEnv)
 	}
 
 	return "", nil

--- a/internal/providers/helper.go
+++ b/internal/providers/helper.go
@@ -1,0 +1,15 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+)
+
+func printEnv(s string, expandEnv bool) {
+	if expandEnv {
+		es := os.ExpandEnv(s)
+		fmt.Print(es)
+		return
+	}
+	fmt.Print(s)
+}


### PR DESCRIPTION
This PR adds support for `expand_env_vars` which will evaluate/expand environment variables passed to extra_env_vars in `generic` ad/kv2 secrets.

Example:

```
kv_secret "consul" {
    path = "services/terraform/consul_backend"
    target_provider = "generic"
    expand_env_vars = true
    attribute_map = {
        "CONSUL_HTTP_TOKEN" = "secretid"
    }
    extra_env_vars = {
        "CONSUL_HTTP_ADDR" = "consul.service.dc1.consul:8501"
        "CONSUL_CACERT" = "$HOME/consul-ca-cert.pem"
        "CONSUL_CLIENT_CERT" = "$HOME/consul-cli-cert.pem"
        "CONSUL_CLIENT_KEY" = "$HOME/consul-cli-key.pem"
        "CONSUL_HTTP_SSL" = "true"
    }
}
```

Produces:

````
CONSUL_HTTP_TOKEN=<SNIP>
CONSUL_CACERT=/Users/oulman/consul-ca-cert.pem
CONSUL_CLIENT_CERT=/Users/oulman/consul-cli-cert.pem
CONSUL_CLIENT_KEY=/Users/oulman/consul-cli-key.pem
CONSUL_HTTP_ADDR=consul.service.dc1.consul.server.ufl.edu:8501
CONSUL_HTTP_SSL=true
```
