### PR TITLE
Adding version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2024 Dylan Northrup
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var tfVaultEnvVersion string
+
+func init() {
+	tfVaultEnvVersion = "0.0.1"
+	rootCmd.AddCommand(versionCmd)
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version",
+	Long:  "Show version of tfvaultenv command",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		logrus.SetFormatter(&logrus.TextFormatter{
+			DisableLevelTruncation: true,
+			PadLevelText:           true,
+			DisableTimestamp:       true,
+		})
+
+		fmt.Printf("tfvaultenv version %s\n", tfVaultEnvVersion)
+	},
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,7 +26,7 @@ import (
 var tfVaultEnvVersion string
 
 func init() {
-	tfVaultEnvVersion = "0.0.1"
+	tfVaultEnvVersion = "0.5.1"
 	rootCmd.AddCommand(versionCmd)
 }
 


### PR DESCRIPTION
Adds a `version` command to show the current version of `tfvaultenv`.  This is to address issue #14 that I filed.

I put my name in the Copyright field of the script. I didn't see any contributions by other folks, so I wasn't sure what, if anything, the process for this is expected to be. Happy to have this adjusted as needed.